### PR TITLE
Update application ports in Docker files

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - "ConnectionStrings:PostgreSQL=Server=moviecritters-postgres;Port=5432;Database=MovieCritters;User Id=admin;Password=123456"
     ports:
-      - 8000:80
+      - 8000:8080
     depends_on:
       - moviecritters-postgres
     restart: always
@@ -33,4 +33,4 @@ services:
     depends_on:
       - moviecritters-api
     ports:
-      - "8001:80"
+      - "8001:8080"

--- a/src/services/MovieCritters.API/Dockerfile
+++ b/src/services/MovieCritters.API/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
+EXPOSE 8081
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src

--- a/src/web/MovieCritters.MVC/Dockerfile
+++ b/src/web/MovieCritters.MVC/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 80
-EXPOSE 443
+EXPOSE 8080
+EXPOSE 8081
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src


### PR DESCRIPTION
.NET 8 changed default ports for applications, and this means Docker port mapping should change too.
Rationale: https://andrewlock.net/exploring-the-dotnet-8-preview-updates-to-docker-images-in-dotnet-8/

This PR updates internal ports from 80 to 8080.
